### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/components/code-viewer.tsx
+++ b/components/code-viewer.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Check, Copy, Download, Maximize, Minimize } from "lucide-react";
 import { useState } from "react";
+import DOMPurify from "dompurify";
 
 interface CodeViewerProps {
   content: string[];
@@ -37,7 +38,7 @@ export function CodeViewer({
       url += `access_token=${githubToken}`;
     }
 
-    return url;
+    return DOMPurify.sanitize(url);
   };
 
   const handleCopy = () => {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "dompurify": "^3.2.4"
   },
   "devDependencies": {
     "@octokit/rest": "^21.1.1",


### PR DESCRIPTION
Potential fix for [https://github.com/nicoxroll/laplace-app/security/code-scanning/2](https://github.com/nicoxroll/laplace-app/security/code-scanning/2)

To fix the problem, we need to ensure that the URL used in the `src` attribute of the `<img>` element is properly sanitized. This can be achieved by using a library like `DOMPurify` to sanitize the URL before using it. `DOMPurify` is a well-known library for sanitizing HTML and URLs to prevent XSS attacks.

1. Install the `DOMPurify` library.
2. Import `DOMPurify` in the `components/code-viewer.tsx` file.
3. Use `DOMPurify` to sanitize the URL returned by the `getImageUrl()` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
